### PR TITLE
feat: Add persistent config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,8 +49,20 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -103,7 +115,54 @@ name = "cp_unfold"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dirs",
+ "serde",
+ "toml",
 ]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -112,16 +171,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "libc"
+version = "0.2.178"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "proc-macro2"
@@ -142,6 +239,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +306,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,10 +379,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -183,4 +406,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+dirs = "5.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Config {
+    pub file_dir: Option<String>,
+    pub library_name: Option<String>,
+    pub library_path: Option<String>,
+}
+
+impl Config {
+    fn config_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|dir| dir.join("cp_unfold").join("config.toml"))
+    }
+
+    pub fn exists() -> bool {
+        Self::config_path()
+            .map(|path| path.exists())
+            .unwrap_or(false)
+    }
+
+    pub fn load() -> Self {
+        let config_path = match Self::config_path() {
+            Some(path) => path,
+            None => return Config::default(),
+        };
+
+        if !config_path.exists() {
+            return Config::default();
+        }
+
+        let content = match fs::read_to_string(&config_path) {
+            Ok(content) => content,
+            Err(_) => return Config::default(),
+        };
+
+        toml::from_str(&content).unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let config_path = Self::config_path()
+            .ok_or("Could not determine config directory")?;
+
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let content = toml::to_string_pretty(self)?;
+        fs::write(&config_path, content)?;
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 mod unfold;
+mod config;
+
 use unfold::Unfold;
+use config::Config;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -8,16 +11,16 @@ use std::path::PathBuf;
 #[command(about = "Unfold Rust source files by expanding imports", long_about = None)]
 struct Args {
     /// Source file name to unfold
-    #[arg(short, long, default_value = "main.rs")]
-    src: String,
+    #[arg(short, long)]
+    src: Option<String>,
 
     /// Library import name (e.g., "library")
-    #[arg(short, long, default_value = "library")]
-    library_name: String,
+    #[arg(short, long)]
+    library_name: Option<String>,
 
     /// Directory containing the source file
     #[arg(short, long)]
-    file_dir: PathBuf,
+    file_dir: Option<PathBuf>,
 
     /// Path to the library directory
     #[arg(short = 'p', long)]
@@ -26,12 +29,79 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
+    let mut config = Config::load();
+    let config_exists = Config::exists();
+
+    // 設定ファイルが存在せず、file_dir が指定されていない場合は標準入力から取得
+    if !config_exists && args.file_dir.is_none() && config.file_dir.is_none() {
+        use std::io::{self, Write};
+
+        eprint!("Enter file directory (source file location): ");
+        io::stderr().flush().unwrap();
+        
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).expect("Failed to read line");
+        let file_dir_input = input.trim().to_string();
+
+        if file_dir_input.is_empty() {
+            eprintln!("Error: file_dir cannot be empty");
+            std::process::exit(1);
+        }
+
+        // 設定を作成して保存
+        let new_config = Config {
+            file_dir: Some(file_dir_input.clone()),
+            library_name: args.library_name.clone(),
+            library_path: args.library_path.as_ref().map(|p| p.display().to_string()),
+        };
+        
+        if let Err(e) = new_config.save() {
+            eprintln!("Warning: Could not save config file: {}", e);
+        } else {
+            eprintln!("Config saved to ~/.config/cp_unfold/config.toml");
+        }
+        
+        config = new_config;
+    }
+
+    // 優先順位: CLI引数 > 設定ファイル > デフォルト値
+    let src = args.src.clone()
+        .or_else(|| config.file_dir.as_ref().map(|_| "main.rs".to_string()))
+        .unwrap_or_else(|| "main.rs".to_string());
+
+    let library_name = args.library_name.clone()
+        .or(config.library_name.clone())
+        .unwrap_or_else(|| "library".to_string());
+
+    let file_dir = args.file_dir.clone()
+        .or_else(|| config.file_dir.as_ref().map(PathBuf::from))
+        .unwrap_or_else(|| {
+            eprintln!("Error: --file-dir is required (or set in config file at ~/.config/cp_unfold/config.toml)");
+            std::process::exit(1);
+        });
+
+    let library_path = args.library_path.clone()
+        .or_else(|| config.library_path.as_ref().map(PathBuf::from));
+
+    // CLI引数で設定が指定された場合も保存（初回のみ）
+    if !config_exists && (args.file_dir.is_some() || args.library_name.is_some() || args.library_path.is_some()) {
+        let new_config = Config {
+            file_dir: args.file_dir.as_ref().map(|p| p.display().to_string()),
+            library_name: args.library_name.clone(),
+            library_path: args.library_path.as_ref().map(|p| p.display().to_string()),
+        };
+        if let Err(e) = new_config.save() {
+            eprintln!("Warning: Could not save config file: {}", e);
+        } else {
+            eprintln!("Config saved to ~/.config/cp_unfold/config.toml");
+        }
+    }
 
     let mut unfold = Unfold::from_args(
-        args.src,
-        args.library_name,
-        args.file_dir,
-        args.library_path,
+        src,
+        library_name,
+        file_dir,
+        library_path,
     );
     let res = unfold.unfold();
 


### PR DESCRIPTION
## Changes
- Add persistent configuration file at `~/.config/cp_unfold/config.toml`
- Interactive setup on first run (prompts for file_dir via stdin if not provided)
- Support for configuration priority: CLI arguments > config file > defaults
- Auto-save config when running with CLI arguments for the first time
- New dependencies: `serde`, `toml`, `dirs` for config management

## Features
- **First run**: If no config exists and no `--file-dir` is provided, prompts user for input
- **Config auto-save**: CLI arguments are saved to config file on first run
- **Priority system**: CLI args override config file values
- **Config location**: `~/.config/cp_unfold/config.toml`

## Usage Examples

### First run (interactive)
```bash
cp_unfold
# Prompts: Enter file directory (source file location): 
# User enters: /home/user/git/rust-kyopro/src
# Config saved to ~/.config/cp_unfold/config.toml
```

### First run (with CLI args)
```bash
cp_unfold --file-dir /home/user/git/rust-kyopro/src
# Config saved to ~/.config/cp_unfold/config.toml
```

### Subsequent runs
```bash
cp_unfold  # Uses saved config
```

### Override config
```bash
cp_unfold --file-dir /other/path  # Temporarily uses different path
```

## Config File Example
```toml
file_dir = "/home/user/git/rust-kyopro/src"
library_name = "library"
```